### PR TITLE
Build firmware with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM archlinux:latest
+WORKDIR /app
+COPY . .
+RUN pacman -Syyu base-devel --noconfirm
+RUN pacman -Syyu arm-none-eabi-gcc --noconfirm
+RUN pacman -Syyu arm-none-eabi-newlib --noconfirm
+RUN pacman -Syyu git --noconfirm
+
+RUN git submodule update --init --recursive
+#RUN make && cp firmware* compiled-firmware/

--- a/compile-with-docker.sh
+++ b/compile-with-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build -t uvk5 .
+docker run -v $(PWD)/compiled-firmware:/app/compiled-firmware uvk5 /bin/bash -c "cd /app && make && cp firmware* compiled-firmware/"


### PR DESCRIPTION
Dockerfile and script to quickly build the firmware without the need to configure a local environment and keep it as a baseline for development.