### PR TITLE
Move frequencies to a single table

### DIFF
--- a/app/aircopy.c
+++ b/app/aircopy.c
@@ -115,7 +115,7 @@ static void AIRCOPY_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		gInputBoxIndex = 0;
 		NUMBER_Get(gInputBox, &Frequency);
 		for (i = 0; i < 7; i++) {
-			if (Frequency >= gLowerLimitFrequencyBandTable[i] && Frequency <= gUpperLimitFrequencyBandTable[i]) {
+			if (Frequency >= LowerLimitFrequencyBandTable[i] && Frequency <= UpperLimitFrequencyBandTable[i]) {
 				gAnotherVoiceID = (VOICE_ID_t)Key;
 				gRxVfo->Band = i;
 				Frequency += 75;

--- a/app/aircopy.c
+++ b/app/aircopy.c
@@ -114,8 +114,8 @@ static void AIRCOPY_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		}
 		gInputBoxIndex = 0;
 		NUMBER_Get(gInputBox, &Frequency);
-		for (i = 0; i < 7; i++) {
-			if (Frequency >= LowerLimitFrequencyBandTable[i] && Frequency <= UpperLimitFrequencyBandTable[i]) {
+		for (i = 0; i < ARRAY_SIZE(FrequencyBandTable); i++) {
+			if (Frequency >= FrequencyBandTable[i].lower && Frequency <= FrequencyBandTable[i].upper) {
 				gAnotherVoiceID = (VOICE_ID_t)Key;
 				gRxVfo->Band = i;
 				Frequency += 75;

--- a/app/app.c
+++ b/app/app.c
@@ -382,10 +382,10 @@ void APP_SetFrequencyByStep(VFO_Info_t *pInfo, int8_t Step)
 	uint32_t Frequency;
 
 	Frequency = pInfo->ConfigRX.Frequency + (Step * pInfo->StepFrequency);
-	if (Frequency > gUpperLimitFrequencyBandTable[pInfo->Band]) {
-		pInfo->ConfigRX.Frequency = gLowerLimitFrequencyBandTable[pInfo->Band];
-	} else if (Frequency < gLowerLimitFrequencyBandTable[pInfo->Band]) {
-		pInfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(gUpperLimitFrequencyBandTable[pInfo->Band], pInfo->StepFrequency, gLowerLimitFrequencyBandTable[pInfo->Band]);
+	if (Frequency > UpperLimitFrequencyBandTable[pInfo->Band]) {
+		pInfo->ConfigRX.Frequency = LowerLimitFrequencyBandTable[pInfo->Band];
+	} else if (Frequency < LowerLimitFrequencyBandTable[pInfo->Band]) {
+		pInfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(UpperLimitFrequencyBandTable[pInfo->Band], pInfo->StepFrequency, LowerLimitFrequencyBandTable[pInfo->Band]);
 	} else {
 		pInfo->ConfigRX.Frequency = Frequency;
 	}

--- a/app/app.c
+++ b/app/app.c
@@ -382,10 +382,10 @@ void APP_SetFrequencyByStep(VFO_Info_t *pInfo, int8_t Step)
 	uint32_t Frequency;
 
 	Frequency = pInfo->ConfigRX.Frequency + (Step * pInfo->StepFrequency);
-	if (Frequency > UpperLimitFrequencyBandTable[pInfo->Band]) {
-		pInfo->ConfigRX.Frequency = LowerLimitFrequencyBandTable[pInfo->Band];
-	} else if (Frequency < LowerLimitFrequencyBandTable[pInfo->Band]) {
-		pInfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(UpperLimitFrequencyBandTable[pInfo->Band], pInfo->StepFrequency, LowerLimitFrequencyBandTable[pInfo->Band]);
+	if (Frequency > FrequencyBandTable[pInfo->Band].upper) {
+		pInfo->ConfigRX.Frequency = FrequencyBandTable[pInfo->Band].lower;
+	} else if (Frequency < FrequencyBandTable[pInfo->Band].lower) {
+		pInfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(FrequencyBandTable[pInfo->Band].upper, pInfo->StepFrequency, FrequencyBandTable[pInfo->Band].lower);
 	} else {
 		pInfo->ConfigRX.Frequency = Frequency;
 	}

--- a/app/main.c
+++ b/app/main.c
@@ -85,7 +85,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 				uint8_t i;
 
 				for (i = 0; i < 7; i++) {
-					if (Frequency <= gUpperLimitFrequencyBandTable[i] && (gLowerLimitFrequencyBandTable[i] <= Frequency)) {
+					if (Frequency <= UpperLimitFrequencyBandTable[i] && (LowerLimitFrequencyBandTable[i] <= Frequency)) {
 						gAnotherVoiceID = (VOICE_ID_t)Key;
 						if (gTxVfo->Band != i) {
 							gTxVfo->Band = i;
@@ -98,7 +98,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 						gTxVfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(
 								Frequency,
 								gTxVfo->StepFrequency,
-								gLowerLimitFrequencyBandTable[gTxVfo->Band]
+								LowerLimitFrequencyBandTable[gTxVfo->Band]
 								);
 						gRequestSaveChannel = 1;
 						return;

--- a/app/main.c
+++ b/app/main.c
@@ -84,8 +84,8 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 			if (gSetting_350EN || (Frequency < 35000000 || Frequency > 39999990)) {
 				uint8_t i;
 
-				for (i = 0; i < 7; i++) {
-					if (Frequency <= UpperLimitFrequencyBandTable[i] && (LowerLimitFrequencyBandTable[i] <= Frequency)) {
+				for (i = 0; i < ARRAY_SIZE(FrequencyBandTable); i++) {
+					if (Frequency <= FrequencyBandTable[i].upper && (FrequencyBandTable[i].lower <= Frequency)) {
 						gAnotherVoiceID = (VOICE_ID_t)Key;
 						if (gTxVfo->Band != i) {
 							gTxVfo->Band = i;
@@ -98,7 +98,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 						gTxVfo->ConfigRX.Frequency = FREQUENCY_FloorToStep(
 								Frequency,
 								gTxVfo->StepFrequency,
-								LowerLimitFrequencyBandTable[gTxVfo->Band]
+								FrequencyBandTable[gTxVfo->Band].lower
 								);
 						gRequestSaveChannel = 1;
 						return;

--- a/app/main.c
+++ b/app/main.c
@@ -116,7 +116,7 @@ static void MAIN_Key_DIGITS(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 			}
 			gInputBoxIndex = 0;
 			Channel = (gInputBox[0] * 10) + gInputBox[1];
-			if (Channel >= 1 && Channel <= 10) {
+			if (Channel >= 1 && Channel <= ARRAY_SIZE(NoaaFrequencyTable)) {
 				Channel += NOAA_CHANNEL_FIRST;
 				gAnotherVoiceID = (VOICE_ID_t)Key;
 				gEeprom.NoaaChannel[Vfo] = Channel;

--- a/app/menu.c
+++ b/app/menu.c
@@ -175,7 +175,7 @@ int MENU_GetLimits(uint8_t Cursor, uint8_t *pMin, uint8_t *pMax)
 	case MENU_SLIST1: case MENU_SLIST2:
 	case MENU_DEL_CH:
 		*pMin = 0;
-		*pMax = 199;
+		*pMax = MR_CHANNEL_LAST;
 		break;
 	case MENU_SAVE: case MENU_MIC:
 		*pMin = 0;

--- a/app/scanner.c
+++ b/app/scanner.c
@@ -242,7 +242,7 @@ static void SCANNER_Key_UP_DOWN(bool bKeyPressed, bool pKeyHeld, int8_t Directio
 		gBeepToPlay = BEEP_1KHZ_60MS_OPTIONAL;
 	}
 	if (gScannerEditState == 1) {
-		gScanChannel = NUMBER_AddWithWraparound(gScanChannel, Direction, 0, 199);
+		gScanChannel = NUMBER_AddWithWraparound(gScanChannel, Direction, 0, MR_CHANNEL_LAST);
 		gShowChPrefix = RADIO_CheckValidChannel(gScanChannel, false, 0);
 		gRequestDisplayScreen = DISPLAY_SCANNER;
 	} else {

--- a/board.c
+++ b/board.c
@@ -675,9 +675,6 @@ void BOARD_EEPROM_Init(void)
 	EEPROM_ReadBuffer(0x0F40, Data, 8);
 	gSetting_F_LOCK         = (Data[0] < 6) ? Data[0] : F_LOCK_OFF;
 
-	gUpperLimitFrequencyBandTable = UpperLimitFrequencyBandTable;
-	gLowerLimitFrequencyBandTable = LowerLimitFrequencyBandTable;
-
 	gSetting_350TX          = (Data[1] < 2) ? Data[1] : true;
 	gSetting_KILLED         = (Data[2] < 2) ? Data[2] : false;
 	gSetting_200TX          = (Data[3] < 2) ? Data[3] : false;

--- a/board.c
+++ b/board.c
@@ -542,8 +542,10 @@ void BOARD_EEPROM_Init(void)
 	gEeprom.MrChannel[1]     = IS_MR_CHANNEL(Data[4])    ? Data[4] : MR_CHANNEL_FIRST;
 	gEeprom.FreqChannel[0]   = IS_FREQ_CHANNEL(Data[2])  ? Data[2] : (FREQ_CHANNEL_FIRST + BAND6_400MHz);
 	gEeprom.FreqChannel[1]   = IS_FREQ_CHANNEL(Data[5])  ? Data[5] : (FREQ_CHANNEL_FIRST + BAND6_400MHz);
+#if defined(ENABLE_NOAA)
 	gEeprom.NoaaChannel[0]   = IS_NOAA_CHANNEL(Data[6])  ? Data[6] : NOAA_CHANNEL_FIRST;
 	gEeprom.NoaaChannel[1]   = IS_NOAA_CHANNEL(Data[7])  ? Data[7] : NOAA_CHANNEL_FIRST;
+#endif
 
 #if defined(ENABLE_FMRADIO)
 	// 0E88..0E8F

--- a/driver/bk1080.c
+++ b/driver/bk1080.c
@@ -21,8 +21,6 @@
 #include "driver/system.h"
 #include "misc.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
 static const uint16_t BK1080_RegisterTable[] = {
 	0x0008, 0x1080, 0x0201, 0x0000,
 	0x40C0, 0x0A1F, 0x002E, 0x02FF,

--- a/frequencies.c
+++ b/frequencies.c
@@ -129,7 +129,7 @@ int FREQUENCY_Check(VFO_Info_t *pInfo)
 {
 	uint32_t Frequency;
 
-	if (pInfo->CHANNEL_SAVE >= NOAA_CHANNEL_FIRST) {
+	if (pInfo->CHANNEL_SAVE > FREQ_CHANNEL_LAST) {
 		return -1;
 	}
 	Frequency = pInfo->pTX->Frequency;

--- a/frequencies.c
+++ b/frequencies.c
@@ -18,34 +18,19 @@
 #include "misc.h"
 #include "settings.h"
 
-const uint32_t LowerLimitFrequencyBandTable[7] = {
-	 5000000,
-	10800000,
-	13600000,
-	17400000,
-	35000000,
-	40000000,
-	47000000,
-};
-
-const uint32_t MiddleFrequencyBandTable[7] = {
-	 6500000,
-	12200000,
-	15000000,
-	26000000,
-	37000000,
-	43500000,
-	55000000,
-};
-
-const uint32_t UpperLimitFrequencyBandTable[7] = {
-	 7600000,
-	13599990,
-	17399990,
-	34999990,
-	39999990,
-	46999990,
-	60000000,
+/* This table maps the available frequencies to bands.
+ *
+ * Note that TX power calibration is stored in EEPROM for this table.
+ * See FREQUENCY_CalculateOutputPower and its callers.
+ * */
+const struct FrequencyBandInfo FrequencyBandTable[7] = {
+       [BAND1_50MHz ] = {.lower =  5000000, .middle =  6500000, .upper =  7600000},
+       [BAND2_108MHz] = {.lower = 10800000, .middle = 12200000, .upper = 13599990},
+       [BAND3_136MHz] = {.lower = 13600000, .middle = 15000000, .upper = 17399990},
+       [BAND4_174MHz] = {.lower = 17400000, .middle = 26000000, .upper = 34999990},
+       [BAND5_350MHz] = {.lower = 35000000, .middle = 37000000, .upper = 39999990},
+       [BAND6_400MHz] = {.lower = 40000000, .middle = 43500000, .upper = 46999990},
+       [BAND7_470MHz] = {.lower = 47000000, .middle = 55000000, .upper = 60000000},
 };
 
 #if defined(ENABLE_NOAA)
@@ -75,29 +60,13 @@ const uint16_t StepFrequencyTable[7] = {
 
 FREQUENCY_Band_t FREQUENCY_GetBand(uint32_t Frequency)
 {
-	if (Frequency >=  5000000 && Frequency <=  7600000) {
-		return BAND1_50MHz;
-	}
-	if (Frequency >= 10800000 && Frequency <= 13599990) {
-		return BAND2_108MHz;
-	}
-	if (Frequency >= 13600000 && Frequency <= 17399990) {
-		return BAND3_136MHz;
-	}
-	if (Frequency >= 17400000 && Frequency <= 34999990) {
-		return BAND4_174MHz;
-	}
-	if (Frequency >= 35000000 && Frequency <= 39999990) {
-		return BAND5_350MHz;
-	}
-	if (Frequency >= 40000000 && Frequency <= 46999990) {
-		return BAND6_400MHz;
-	}
-	if (Frequency >= 47000000 && Frequency <= 60000000) {
-		return BAND7_470MHz;
-	}
-
-	return BAND6_400MHz;
+    for(int i = 0; i < ARRAY_SIZE(FrequencyBandTable); i++) {
+        if(Frequency >= FrequencyBandTable[i].lower && Frequency <= FrequencyBandTable[i].upper) {
+            return i;
+        }
+    }
+    //TODO Strange default here
+    return BAND6_400MHz;
 }
 
 uint8_t FREQUENCY_CalculateOutputPower(uint8_t TxpLow, uint8_t TxpMid, uint8_t TxpHigh, int32_t LowerLimit, int32_t Middle, int32_t UpperLimit, int32_t Frequency)

--- a/frequencies.h
+++ b/frequencies.h
@@ -32,9 +32,13 @@ enum FREQUENCY_Band_t {
 
 typedef enum FREQUENCY_Band_t FREQUENCY_Band_t;
 
-extern const uint32_t LowerLimitFrequencyBandTable[7];
-extern const uint32_t MiddleFrequencyBandTable[7];
-extern const uint32_t UpperLimitFrequencyBandTable[7];
+
+struct FrequencyBandInfo {
+    uint32_t lower;
+    uint32_t upper;
+    uint32_t middle;
+};
+extern const struct FrequencyBandInfo FrequencyBandTable[7];
 #if defined(ENABLE_NOAA)
 extern const uint32_t NoaaFrequencyTable[10];
 #endif

--- a/misc.c
+++ b/misc.c
@@ -47,7 +47,7 @@ uint16_t gEEPROM_RSSI_CALIB[3][4];
 uint16_t gEEPROM_1F8A;
 uint16_t gEEPROM_1F8C;
 
-uint8_t gMR_ChannelAttributes[207];
+uint8_t gMR_ChannelAttributes[FREQ_CHANNEL_LAST + 1];
 
 volatile bool gNextTimeslice500ms;
 volatile uint16_t gBatterySaveCountdown = 1000;

--- a/misc.c
+++ b/misc.c
@@ -17,9 +17,6 @@
 #include <string.h>
 #include "misc.h"
 
-const uint32_t *gUpperLimitFrequencyBandTable;
-const uint32_t *gLowerLimitFrequencyBandTable;
-
 bool gSetting_350TX;
 bool gSetting_KILLED;
 bool gSetting_200TX;

--- a/misc.h
+++ b/misc.h
@@ -20,22 +20,32 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "frequencies.h"
 
 #define ARRAY_SIZE(a)    (sizeof(a) / sizeof(a[0]))
 
 #define IS_MR_CHANNEL(x) ((x) >= MR_CHANNEL_FIRST && (x) <= MR_CHANNEL_LAST)
 #define IS_FREQ_CHANNEL(x) ((x) >= FREQ_CHANNEL_FIRST && (x) <= FREQ_CHANNEL_LAST)
+#if defined(ENABLE_NOAA)
 #define IS_NOAA_CHANNEL(x) ((x) >= NOAA_CHANNEL_FIRST && (x) <= NOAA_CHANNEL_LAST)
 #define IS_NOT_NOAA_CHANNEL(x) ((x) >= MR_CHANNEL_FIRST && (x) <= FREQ_CHANNEL_LAST)
-#define IS_VALID_CHANNEL(x) ((x) <= NOAA_CHANNEL_LAST)
+#else
+/* If NOAA is not enabled, it cannot be a NOAA channel */
+#define IS_NOAA_CHANNEL(x) (false)
+#define IS_NOT_NOAA_CHANNEL(x) (true)
+#endif
+#define IS_VALID_CHANNEL(x) ((x) < LAST_CHANNEL)
 
 enum {
 	MR_CHANNEL_FIRST = 0U,
 	MR_CHANNEL_LAST = 199U,
 	FREQ_CHANNEL_FIRST = 200U,
 	FREQ_CHANNEL_LAST = 206U,
+#if defined(ENABLE_NOAA)
 	NOAA_CHANNEL_FIRST = 207U,
-	NOAA_CHANNEL_LAST = 216U,
+	NOAA_CHANNEL_LAST = NOAA_CHANNEL_FIRST + ARRAY_SIZE(NoaaFrequencyTable),
+#endif
+        LAST_CHANNEL,
 };
 
 enum {

--- a/misc.h
+++ b/misc.h
@@ -85,9 +85,6 @@ enum CssScanMode_t {
 
 typedef enum CssScanMode_t CssScanMode_t;
 
-extern const uint32_t *gUpperLimitFrequencyBandTable;
-extern const uint32_t *gLowerLimitFrequencyBandTable;
-
 extern bool gSetting_350TX;
 extern bool gSetting_KILLED;
 extern bool gSetting_200TX;

--- a/misc.h
+++ b/misc.h
@@ -20,6 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+
+#define ARRAY_SIZE(a)    (sizeof(a) / sizeof(a[0]))
+
 #define IS_MR_CHANNEL(x) ((x) >= MR_CHANNEL_FIRST && (x) <= MR_CHANNEL_LAST)
 #define IS_FREQ_CHANNEL(x) ((x) >= FREQ_CHANNEL_FIRST && (x) <= FREQ_CHANNEL_LAST)
 #define IS_NOAA_CHANNEL(x) ((x) >= NOAA_CHANNEL_FIRST && (x) <= NOAA_CHANNEL_LAST)

--- a/radio.c
+++ b/radio.c
@@ -315,12 +315,12 @@ void RADIO_ConfigureChannel(uint8_t VFO, uint32_t Arg)
 	}
 
 	Frequency = pRadio->ConfigRX.Frequency;
-	if (Frequency < gLowerLimitFrequencyBandTable[Band]) {
-		pRadio->ConfigRX.Frequency = gLowerLimitFrequencyBandTable[Band];
-	} else if (Frequency > gUpperLimitFrequencyBandTable[Band]) {
-		pRadio->ConfigRX.Frequency = gUpperLimitFrequencyBandTable[Band];
+	if (Frequency < LowerLimitFrequencyBandTable[Band]) {
+		pRadio->ConfigRX.Frequency = LowerLimitFrequencyBandTable[Band];
+	} else if (Frequency > UpperLimitFrequencyBandTable[Band]) {
+		pRadio->ConfigRX.Frequency = UpperLimitFrequencyBandTable[Band];
 	} else if (Channel >= FREQ_CHANNEL_FIRST) {
-		pRadio->ConfigRX.Frequency = FREQUENCY_FloorToStep(pRadio->ConfigRX.Frequency, gEeprom.VfoInfo[VFO].StepFrequency, gLowerLimitFrequencyBandTable[Band]);
+		pRadio->ConfigRX.Frequency = FREQUENCY_FloorToStep(pRadio->ConfigRX.Frequency, gEeprom.VfoInfo[VFO].StepFrequency, LowerLimitFrequencyBandTable[Band]);
 	}
 
 	if (Frequency >= 10800000 && Frequency <= 13599990) {

--- a/radio.c
+++ b/radio.c
@@ -95,10 +95,8 @@ uint8_t RADIO_FindNextChannel(uint8_t Channel, int8_t Direction, bool bCheckScan
 {
 	uint8_t i;
 
-	for (i = 0; i < 200; i++) {
-		if (Channel == 0xFF) {
-			Channel = MR_CHANNEL_LAST;
-		} else if (Channel > MR_CHANNEL_LAST) {
+	for (i = 0; i <= MR_CHANNEL_LAST; i++) {
+		if (Channel > MR_CHANNEL_LAST) {
 			Channel = MR_CHANNEL_FIRST;
 		}
 		if (RADIO_CheckValidChannel(Channel, bCheckScanList, VFO)) {

--- a/radio.c
+++ b/radio.c
@@ -430,10 +430,12 @@ void RADIO_ApplyOffset(VFO_Info_t *pInfo)
 		break;
 	}
 
-	if (Frequency < 5000000) {
-		Frequency = 5000000;
-	} else if (Frequency > 60000000) {
-		Frequency = 60000000;
+        /* Lowest is lower limit of FrequencyBandTable*/
+	if (Frequency < FrequencyBandTable[0].lower) {
+		Frequency = FrequencyBandTable[0].lower;
+        /* Lowest is upper limit of FrequencyBandTable*/
+	} else if (Frequency > FrequencyBandTable[ARRAY_SIZE(FrequencyBandTable) - 1].upper) {
+		Frequency = FrequencyBandTable[ARRAY_SIZE(FrequencyBandTable) - 1].upper;
 	}
 
 	pInfo->ConfigTX.Frequency = Frequency;

--- a/radio.c
+++ b/radio.c
@@ -188,7 +188,7 @@ void RADIO_ConfigureChannel(uint8_t VFO, uint32_t Arg)
 			gEeprom.ScreenChannel[VFO] = gEeprom.FreqChannel[VFO];
 		}
 		Index = Channel - FREQ_CHANNEL_FIRST;
-		RADIO_InitInfo(pRadio, Channel, Index, gLowerLimitFrequencyBandTable[Index]);
+		RADIO_InitInfo(pRadio, Channel, Index, FrequencyBandTable[Index].lower);
 		return;
 	}
 
@@ -315,12 +315,12 @@ void RADIO_ConfigureChannel(uint8_t VFO, uint32_t Arg)
 	}
 
 	Frequency = pRadio->ConfigRX.Frequency;
-	if (Frequency < LowerLimitFrequencyBandTable[Band]) {
-		pRadio->ConfigRX.Frequency = LowerLimitFrequencyBandTable[Band];
-	} else if (Frequency > UpperLimitFrequencyBandTable[Band]) {
-		pRadio->ConfigRX.Frequency = UpperLimitFrequencyBandTable[Band];
+	if (Frequency < FrequencyBandTable[Band].lower) {
+		pRadio->ConfigRX.Frequency = FrequencyBandTable[Band].lower;
+	} else if (Frequency > FrequencyBandTable[Band].upper) {
+		pRadio->ConfigRX.Frequency = FrequencyBandTable[Band].upper;
 	} else if (Channel >= FREQ_CHANNEL_FIRST) {
-		pRadio->ConfigRX.Frequency = FREQUENCY_FloorToStep(pRadio->ConfigRX.Frequency, gEeprom.VfoInfo[VFO].StepFrequency, LowerLimitFrequencyBandTable[Band]);
+		pRadio->ConfigRX.Frequency = FREQUENCY_FloorToStep(pRadio->ConfigRX.Frequency, gEeprom.VfoInfo[VFO].StepFrequency, FrequencyBandTable[Band].lower);
 	}
 
 	if (Frequency >= 10800000 && Frequency <= 13599990) {
@@ -408,9 +408,9 @@ void RADIO_ConfigureSquelchAndOutputPower(VFO_Info_t *pInfo)
 				Txp[0],
 				Txp[1],
 				Txp[2],
-				LowerLimitFrequencyBandTable[Band],
-				MiddleFrequencyBandTable[Band],
-				UpperLimitFrequencyBandTable[Band],
+				FrequencyBandTable[Band].lower,
+				FrequencyBandTable[Band].middle,
+				FrequencyBandTable[Band].upper,
 				pInfo->pTX->Frequency);
 }
 


### PR DESCRIPTION
Move the 3 frequency table to a single table. this allows to change some magic number 7 in to a ARRAY_SIZE.
Changed some magic numbers related to memory to the appropriate size.

This allows to change the frequency table without forgetting some possible corner cases.